### PR TITLE
Avoid definition conflicts

### DIFF
--- a/lib/picowi_defs.h
+++ b/lib/picowi_defs.h
@@ -23,8 +23,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifndef MIN
 #define MIN(a,b) (((a)<(b))?(a):(b))
+#endif
+
+#ifndef MAX
 #define MAX(a,b) (((a)>(b))?(a):(b))
+#endif
 
 typedef unsigned char   BYTE;
 typedef unsigned short  WORD;


### PR DESCRIPTION
MIN and MAX may already be defined in another library such as platform.h in the pico-sdk library